### PR TITLE
Fix error in how to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ Important: Because of old browsers (e.g. IE6, IE7), we recommend to implement th
         }
     }
     //call plugin function after DOM ready
-    addLoadEvent(
+    addLoadEvent(function() {
         outdatedBrowser({
             bgColor: '#f25648',
             color: '#ffffff',
             lowerThan: 'transform',
             languagePath: 'your_path/outdatedbrowser/lang/en.html'
         })
-    );
+    });
     ```    
 <br>
 — Using jQuery (version that supports IE&lt;9) <br>


### PR DESCRIPTION
The current setup instructions produces the following error 

> Uncaught TypeError: undefined is not a function

This results in `outdatedBrowser` being called immediately.

This fixes #91.
