### PR TITLE
borderColor not supported by IE8

### DIFF
--- a/outdatedbrowser/outdatedbrowser.js
+++ b/outdatedbrowser/outdatedbrowser.js
@@ -134,7 +134,7 @@ var outdatedBrowser = function(options) {
 
         //check settings attributes
         btnUpdate.style.color = txtColor;
-        btnUpdate.style.borderColor = txtColor;
+        if(btnUpdate.style.borderColor) btnUpdate.style.borderColor = txtColor;
         btnClose.style.color = txtColor;
 
         //close button


### PR DESCRIPTION
check if this attribute is available on the element, otherwise ignore it. This ensures that there are no script errors on IE8
