### PR TITLE
Added `test` option

### DIFF
--- a/outdatedbrowser/outdatedbrowser.js
+++ b/outdatedbrowser/outdatedbrowser.js
@@ -8,14 +8,16 @@ website:    http://www.burocratik.com
 var outdatedBrowser = function(options) {
 
     //Variable definition (before ajax)
-    var outdated = document.getElementById("outdated");
+    var outdated = document.getElementById("outdated"),
+        test;
 
     // Default settings
     this.defaultOpts = {
         bgColor: '#f25648',
         color: '#ffffff',
         lowerThan: 'transform',
-        languagePath: '../outdatedbrowser/lang/en.html'
+        languagePath: '../outdatedbrowser/lang/en.html',
+        test: false
     }
 
     if (options) {
@@ -34,16 +36,19 @@ var outdatedBrowser = function(options) {
         this.defaultOpts.color = options.color;
         this.defaultOpts.lowerThan = options.lowerThan;
         this.defaultOpts.languagePath = options.languagePath;
+        this.defaultOpts.test = options.test;
 
         bkgColor = this.defaultOpts.bgColor;
         txtColor = this.defaultOpts.color;
         cssProp = this.defaultOpts.lowerThan;
         languagePath = this.defaultOpts.languagePath;
+        test = this.defaultOpts.test;
     } else {
         bkgColor = this.defaultOpts.bgColor;
         txtColor = this.defaultOpts.color;
         cssProp = this.defaultOpts.lowerThan;
         languagePath = this.defaultOpts.languagePath;
+        test = this.defaultOpts.test;
     };//end if options
 
 
@@ -100,7 +105,7 @@ var outdatedBrowser = function(options) {
     })();
 
     //if browser does not supports css3 property (transform=default), if does > exit all this
-    if ( !supports(''+ cssProp +'') ) {
+    if ( test || !supports(''+ cssProp +'') ) {
         if (done && outdated.style.opacity !== '1') {
             done = false;
             for (var i = 1; i <= 100; i++) {


### PR DESCRIPTION
Regarding issue #149, I added a `test` property to the options. Set it to true to always show the banner on load (for testing purposes). I didn't update the documentation because that can easily be updated to the way you guys like it.

I followed how things are currently done in the code; however, there's some unnecessary assignment going on. You might as well assign the property in `options` straight to the variable in this code:

```
this.defaultOpts.bgColor = options.bgColor;
this.defaultOpts.color = options.color;
this.defaultOpts.lowerThan = options.lowerThan;
this.defaultOpts.languagePath = options.languagePath;
this.defaultOpts.test = options.test;

bkgColor = this.defaultOpts.bgColor;
txtColor = this.defaultOpts.color;
cssProp = this.defaultOpts.lowerThan;
languagePath = this.defaultOpts.languagePath;
test = this.defaultOpts.test;
```

I think the main intent was something like this though:

```
bkgColor = options.bgColor || this.defaultOpts.bgColor;
txtColor = options.color || this.defaultOpts.color;
cssProp = options.lowerThan || this.defaultOpts.lowerThan;
languagePath = options.languagePath != null ? options.languagePath : this.defaultOpts.languagePath;
test = options.test || this.defaultOpts.test;
```

Also, these variables are global. They're not private. I'm going to go through the code and clean it up.

Additionally, the code needs to be minified... I'm not sure what minifier you used so I didn't do it (it would be nice to have a build script)
