### PR TITLE
Don't ignore the entire library in Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,6 @@
     "outdatedbrowser/lang"
   ],
   "ignore": [
-    "**/.*",
     "bower_components"
   ],
   "dependencies": {


### PR DESCRIPTION
I'm not sure what happened here exactly, but `bower.json` is currently configured to ignore all files with file extensions, rendering outdated-browser (unfortunately) useless when installed with Bower. This fixes that.