### PR TITLE
Add package.json for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "outdated-browser",
+  "version": "1.0.0",
+  "description": "A time saving tool for developers. It detects outdated browsers and advises users to upgrade to a new version.",
+  "main": "outdatedbrowser/outdatedbrowser.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/burocratik/outdated-browser.git"
+  },
+  "author": "Bürocratik <hello@burocratik.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/burocratik/outdated-browser/issues"
+  },
+  "homepage": "http://outdatedbrowser.com"
+}


### PR DESCRIPTION
I like your project. I would like to bundle it in a Browserify context and I would like to contribute this package.json as a first step so that npm allows adding it as a Github dependency. Thanks for merging. :)

I would be even nicer if you could publish it as an npm package so that someone else can easily do ```npm install outdated-browser```.