### PR TITLE
Revert "DE typo fix" – that typo fix introduced a new typo 

### DIFF
--- a/outdatedbrowser/lang/de.html
+++ b/outdatedbrowser/lang/de.html
@@ -1,3 +1,3 @@
  <h6>Ihr Browser ist veraltet!</h6>
- <p>Bitte aktualisieren Sie Ihren Browser, um diese Website korrekt dazustellen. <a id="btnUpdateBrowser" href="http://outdatedbrowser.com/de">Den Browser jetzt aktualisieren </a></p>
+ <p>Bitte aktualisieren Sie Ihren Browser, um diese Website korrekt darzustellen. <a id="btnUpdateBrowser" href="http://outdatedbrowser.com/de">Den Browser jetzt aktualisieren </a></p>
  <p class="last"><a href="#" id="btnCloseUpdateBrowser" title="Schließen">&times;</a></p>


### PR DESCRIPTION
This reverts commit 8b5175b76ed12099ba785241e0bfae14421fbff0.

"Dazustellen" means putting it somewhere, "darzustellen" is the correct
verb for display it.

This was fixed earlier by db861b91da4ff9784a52e42635f70295fbbc8b9f and
broken by 8b5175b76ed12099ba785241e0bfae14421fbff0.